### PR TITLE
Fixing locked screen after dismissing notification

### DIFF
--- a/src/views/DefaultPopup.js
+++ b/src/views/DefaultPopup.js
@@ -115,10 +115,9 @@ export default class DefaultPopup extends Component {
       onPress, appIconSource, appTitle, timeText, title, body
     } = this.state;
 
-    return (
+    return !!show && (
       <View style={styles.fullScreenContainer}>
         {
-          !!show &&
           <Animated.View
             style={getAnimatedContainerStyle({containerSlideOffsetY, containerDragOffsetY, containerScale})}
             {...this._panResponder.panHandlers}>


### PR DESCRIPTION
Previously when we would swipe the notification away the View component wrapping Animated.View would still remain and the rest of the application would not be accessible.

Moving the show flag outside the View component fixes this issue.