### PR TITLE
Make the onpress handler a little more lenient

### DIFF
--- a/src/views/DefaultPopup.js
+++ b/src/views/DefaultPopup.js
@@ -90,7 +90,7 @@ export default class DefaultPopup extends Component {
   _onPanResponderMove = (e, gestureState) => {
     // console.log('_onPanResponderMove', gestureState);  // DEBUG
     const { containerDragOffsetY } = this.state;
-    
+
     // Prevent dragging down too much
     const newDragOffset = gestureState.dy < 100 ? gestureState.dy : 100;  // TODO: customize
     containerDragOffsetY.setValue(newDragOffset);


### PR DESCRIPTION
Sometimes it can be difficult to fire the onpress on a phone because you end up moving the notification slightly instead of pressing it. This PR just adds a slight lenience so it's easier to fire the onpress