### PR TITLE
make renderPopupContent prop optional

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -19,7 +19,7 @@ declare module "react-native-push-notification-popup" {
   }
 
   interface PushNotificationPopupProps {
-    renderPopupContent: (options: ContentOptionsBase) => ReactElement;
+    renderPopupContent?: (options: ContentOptionsBase) => ReactElement;
   }
 
   export default class ReactNativePushNotificationPopup extends Component<PushNotificationPopupProps, any> {


### PR DESCRIPTION
Hi, thanks for creating this package!

I believe that the `renderPopupContent` prop should be optional, as the docs suggest, this PR adjusts the types accordingly.
Please let me know if you have any suggestions or request :)